### PR TITLE
rewording of petition status

### DIFF
--- a/app/assets/stylesheets/petitions.scss
+++ b/app/assets/stylesheets/petitions.scss
@@ -181,8 +181,8 @@ a     { text-decoration:none; color:#005a85; }
     .petition-details.history       { margin:0 0 0 1%; background:#bcf9c7; }
       .petition-details.history h2      { color:#1ba734; }
 
-  .petitie_field_label            { float: left; width: 40%; font-weight: bold; padding: 0 0 5px 0;}
-  .petitie_field_data             { float: left; width: 58%; padding: 0 0 5px 0;}
+  .petition_field_label            { float: left; width: 40%; font-weight: bold; padding: 0 0 5px 0;}
+  .petition_field_data             { float: left; width: 58%; padding: 0 0 5px 0;}
 
   .social-bar                     { padding:18px 0; background:#898989; }
     .social-bar-content             { width:1160px; margin:0 auto; padding:0 12% 0 0; font:400 18px/21px 'Open Sans', arial, sans-serif; color:#e5e5e5; text-align:center; }

--- a/app/views/petitions/index.html.slim
+++ b/app/views/petitions/index.html.slim
@@ -37,7 +37,7 @@ div.page
       
       div.clearfix
       
-      = link_to 'All petitions', all_petitions_path, class: 'navigation-toall'
+      = link_to t('index.all'), all_petitions_path, class: 'navigation-toall'
   
   aside.news-intro-blocks-container
     div.news-intro-block

--- a/app/views/petitions/index.html.slim
+++ b/app/views/petitions/index.html.slim
@@ -44,13 +44,13 @@ div.page
       h2.news-intro-block-title= @news[0].title
       div.news-intro-block-date= @news[0].date
       div.news-intro-block-intro= @news[0].intro_text
-      a.news-intro-block-intro-read-more href="#" Lees verder
+      a.news-intro-block-intro-read-more href="#" = t('index.read')
 
     div.news-intro-block.right
       h2.news-intro-block-title= @news[1].title
       div.news-intro-block-date= @news[1].date
       div.news-intro-block-intro= @news[1].intro_text
-      a.news-intro-block-intro-read-more href="#" Lees verder
+      a.news-intro-block-intro-read-more href="#" = t('index.read')
 
 / p id="notice"
 /   = notice

--- a/app/views/petitions/show.html.slim
+++ b/app/views/petitions/show.html.slim
@@ -90,31 +90,31 @@ div.page
     section.petition-details-container
       div.petition-details
         h2.petition-section-title= t('show.overview.title')
-        div.petitie_field_label= t('show.overview.addressee')
-        div.petitie_field_data
+        div.petition_field_label= t('show.overview.addressee')
+        div.petition_field_data
         - if @petition.organisation_id
-          div.petitie_field_data= @petition.organisation_id
-        div.petitie_field_label= t('show.overview.desk')
+          div.petition_field_data= @petition.organisation_id
+        div.petition_field_label= t('show.overview.desk')
         - if @office
-          div.petitie_field_data= @office.name
-        div.petitie_field_label= t('show.overview.end_date')
+          div.petition_field_data= @office.name
+        div.petition_field_label= t('show.overview.end_date')
         - if @petition.date_projected
-          div.petitie_field_data= @petition.date_projected.strftime('%d-%m-%Y')
-        div.petitie_field_label= t('show.overview.status')
-        div.petitie_field_data
+          div.petition_field_data= @petition.date_projected.strftime('%d-%m-%Y')
+        div.petition_field_label= t('show.overview.status')
+        div.petition_field_data
         - if @petition.status
-          div.petitie_field_data= @petition.status
-        div.petitie_field_label= t('show.overview.petitioners')
-        div.petitie_field_data
+          div.petition_field_data= @petition.status
+        div.petition_field_label= t('show.overview.petitioners')
+        div.petition_field_data
         - if @petition.petitioner_name
-          div.petitie_field_data= @petition.petitioner_name
-        div.petitie_field_label= t('show.overview.organisation')
-        div.petitie_field_data
+          div.petition_field_data= @petition.petitioner_name
+        div.petition_field_label= t('show.overview.organisation')
+        div.petition_field_data
         - if @petition.petitioner_organisation
-          div.petitie_field_data= @petition.petitioner_organisation
-        div.petitie_field_label= t('show.overview.website')  
+          div.petition_field_data= @petition.petitioner_organisation
+        div.petition_field_label= t('show.overview.website')  
         - if @petition.links[:links].present?
-          div.petitie_field_data
+          div.petition_field_data
             - @petition.links[:links].each do |link|
               a href="#{link[:link]}"= link[:text]                   
               br

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,6 +121,7 @@ en:
     whilesigning: While signing a petition
     title: Help
   index:
+    all: All petitions
     more: Show more petitions
     sort:
       active: Active petitions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,6 +123,7 @@ en:
   index:
     all: All petitions
     more: Show more petitions
+    read: Read more... 
     sort:
       active: Active petitions
       biggest: Biggest petitions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
       open: Open for signing
       rejected: Rejected
       sign_elsewhere: Sign elsewhere
-      title: 'Petition status: '
+      title: 'Sort on: '
     title: All petitions
   anonymous: Anonymous
   confirm:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -121,7 +121,8 @@ nl:
     whilesigning: Bij het ondertekenen
     title: Help
   index:
-    more: meer petities tonen...
+    all: Alle petities
+    more: Meer petities tonen
     sort:
       active: Actieve petities
       biggest: Grootste petities

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -34,7 +34,7 @@ nl:
       open: Ondertekenbaar
       rejected: Afgewezen
       sign_elsewhere: Elders te tekenen
-      title: 'Petitie status: '
+      title: 'Sorteren op: '
     title: Alle petities
   anonymous: Anoniem
   confirm:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -123,6 +123,7 @@ nl:
   index:
     all: Alle petities
     more: Meer petities tonen
+    read: Lees verder... 
     sort:
       active: Actieve petities
       biggest: Grootste petities


### PR DESCRIPTION
The expression ‘petition status’ is too abstract for some users. The
instruction ‘sort on’ is active and more inviting. Also the same as on
index page.
