### PR TITLE
Changed text_field input to email_field

### DIFF
--- a/app/views/petitions/_signform.html.slim
+++ b/app/views/petitions/_signform.html.slim
@@ -8,7 +8,7 @@ div.petition-form-float-wrapper
     = f.label :person_name, t('show.sign.form.name.label')
     = f.text_field :person_name, class: 'petition-form-textfield', placeholder: t('show.sign.form.name.placeholder')
     = f.label :person_email, t('show.sign.form.email.label')
-    = f.text_field :person_email, class: 'petition-form-textfield', placeholder: t('show.sign.form.email.placeholder')
+    = f.email_field :person_email, class: 'petition-form-textfield', placeholder: t('show.sign.form.email.placeholder')
     = f.label :person_city, t('show.sign.form.residence.label')
     = f.text_field :person_city, class: 'petition-form-textfield', placeholder: t('show.sign.form.residence.placeholder')
     = f.check_box :visible, class: 'petition-form-checkbox', id: 'petition-form-checkbox'


### PR DESCRIPTION
Use a `type="email"` text field to allow mobile devices to display the keyboard optimised for entering email addresses.