### PR TITLE
Removed create button on newsletter index page

### DIFF
--- a/app/admin/newsletter.rb
+++ b/app/admin/newsletter.rb
@@ -6,6 +6,9 @@ ActiveAdmin.register Newsletter do
   filter :published
   filter :date
 
+  # Remove create button on index page, as petition_id is always required
+  config.action_items.delete_at(0)
+
   index do
     selectable_column
     id_column

--- a/test/admin/newsletters_controller_test.rb
+++ b/test/admin/newsletters_controller_test.rb
@@ -10,6 +10,12 @@ module Admin
     test 'should get index' do
       get :index
       assert_response :success
+      assert_select 'div.action_items', ''
+    end
+
+    test 'should get new' do
+      get :new
+      assert_response :success
     end
 
     test 'should get show' do


### PR DESCRIPTION
The Newsletter model requires a petition_id and the form in ActiveAdmin does not provide a way to enter that field. You can create a newsletter from the petition detail page.