### PR TITLE
Enable markdown footnotes

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -5,7 +5,8 @@ module MarkdownHelper
       fenced_code_blocks: false,
       disable_indented_code_blocks: true,
       strikethrough: true,
-      tables: true
+      tables: true,
+      footnotes: true
     )
     renderer.render(text.to_s).html_safe if text
   end
@@ -22,5 +23,7 @@ end
 Slim::Embedded.options[:markdown] = {
   fenced_code_blocks: false,
   disable_indented_code_blocks: true,
-  strikethrough: true
+  strikethrough: true,
+  tables: true,
+  footnotes: true
 }

--- a/test/helpers/markdown_helper_test.rb
+++ b/test/helpers/markdown_helper_test.rb
@@ -30,4 +30,12 @@ Groningen | 583.635
 Drenthe | 488.505'
     assert_match '<table>', markdown(text).strip
   end
+
+  test 'markdown should render footnotes' do
+    text = 'This is a test[^1] string.
+
+[^1]: test: a procedure for checking quality.'
+    assert_match '<sup id="fnref1">', markdown(text).strip
+    assert_match '<div class="footnotes">', markdown(text).strip
+  end
 end


### PR DESCRIPTION
It would be possible to use footnotes[^1] in a markdown rendered text.

[^1]: This would an example of a footnote.